### PR TITLE
clean up platform differences

### DIFF
--- a/build_vtk.py
+++ b/build_vtk.py
@@ -19,58 +19,6 @@ def clone_vtk(branch="v8.1.0", dir="src/vtk"):
     subprocess.check_call(clone_cmd, shell=True)
 
 
-def download_install_ninja_win(version="1.8.2", zip_file="src/ninja.zip"):
-    os.makedirs(os.path.dirname(zip_file), exist_ok=True)
-    if not os.path.isfile(zip_file):
-        print(f"> downloading ninja v{version}")
-        from urllib.request import urlretrieve
-        url = f"https://github.com/ninja-build/ninja/releases/download/v{version}/ninja-win.zip"
-        urlretrieve(url, zip_file)
-
-    current = subprocess.check_output("ninja --version", shell=True).decode().strip()
-    if version != current:
-        print(f"> overwriting ninja (v{current}) with v{version}")
-        scripts_dir = os.path.join(sys.prefix, "Scripts")
-        import zipfile
-        with zipfile.ZipFile(zip_file, 'r') as zh:
-            zh.extractall(scripts_dir)
-
-        current = subprocess.check_output("ninja --version", shell=True).decode().strip()
-        if version != current:
-            exit(f"> overwriting ninja FAILED")
-        print(f"> overwriting ninja succeeded")
-
-
-def download_install_cmake_win(major_version="3.10", version="3.10.2", zip_file="src/cmake.zip"):
-    os.makedirs(os.path.dirname(zip_file), exist_ok=True)
-    if not os.path.isfile(zip_file):
-        print(f"> downloading cmake v{version}")
-        from urllib.request import urlretrieve
-        url = f"https://cmake.org/files/v{major_version}/cmake-{version}-win64-x64.zip"
-        print(url)
-        urlretrieve(url, zip_file)
-
-        print(f"> overwriting cmake with v{version}")
-        scripts_dir = os.path.join(sys.prefix, "Lib", "site-packages", "cmake", "data")
-        import zipfile
-        with zipfile.ZipFile(zip_file, 'r') as zh:
-            zh.extractall(scripts_dir)
-
-        print(f"> overwriting cmake succeeded")
-
-
-def generate_libpython(filepath="work/vtk/libpython.notreally"):
-    """
-    According to PEP513 you are not allowed to link against libpythonxxx.so. However, CMake demands it. So here you go.
-    An empty libpythonxxx.so.
-    """
-    if not os.path.exists(filepath):
-        os.makedirs(os.path.dirname(filepath), exist_ok=True)
-        with open(filepath, mode='w') as fh:
-            fh.write('')
-    return filepath
-
-
 def build_vtk(src="../../src/vtk",
               work="work/vtk",
               build="../../build_vtk",
@@ -79,7 +27,13 @@ def build_vtk(src="../../src/vtk",
               install_dev=True,
               clean_cmake_cache=True):
     """Build and install VTK using CMake."""
-    python_library = setup_utils.get_python_lib(root=work)
+    if not is_win:
+        # on linux/macOS, generate an empty libpython file to link against for PEP513 compliance
+        subprocess.check_call(f"touch {work}/libpython.fake", shell=True)
+        python_library = os.path.abspath(os.path.join(work, "libpython.fake"))
+    else:
+        # on Windows that is not supported and we need the real pythonXY.lib file
+        python_library = setup_utils.get_python_lib()
     python_include_dir = setup_utils.get_python_include_dir()
     site_packages_dir = os.path.relpath(setup_utils.get_site_packages_dir(), sys.prefix)
 
@@ -93,7 +47,7 @@ def build_vtk(src="../../src/vtk",
     cmake_cmd = ["cmake"]
     if clean_cmake_cache and os.path.exists(work):
         if is_win:
-            cmake_cmd.append('"-U *"')
+            cmake_cmd.append('"-U *"')  # needs to be quoted on windows because cmake's CLI is inconsistent
         else:
             cmake_cmd.append("-U *")
     cmake_cmd.extend([
@@ -151,9 +105,50 @@ def build_vtk(src="../../src/vtk",
     subprocess.check_call(build_cmd, shell=True, cwd=work)
 
 
+def download_install_ninja_win(version="1.8.2", zip_file="src/ninja.zip"):
+    os.makedirs(os.path.dirname(zip_file), exist_ok=True)
+    if not os.path.isfile(zip_file):
+        print(f"> downloading ninja v{version}")
+        from urllib.request import urlretrieve
+        url = f"https://github.com/ninja-build/ninja/releases/download/v{version}/ninja-win.zip"
+        urlretrieve(url, zip_file)
+
+    current = subprocess.check_output("ninja --version", shell=True).decode().strip()
+    if version != current:
+        print(f"> overwriting ninja (v{current}) with v{version}")
+        scripts_dir = os.path.join(sys.prefix, "Scripts")
+        import zipfile
+        with zipfile.ZipFile(zip_file, 'r') as zh:
+            zh.extractall(scripts_dir)
+
+        current = subprocess.check_output("ninja --version", shell=True).decode().strip()
+        if version != current:
+            exit(f"> overwriting ninja FAILED")
+        print(f"> overwriting ninja succeeded")
+
+
+def download_install_cmake_win(major_version="3.10", version="3.10.2", zip_file="src/cmake.zip"):
+    os.makedirs(os.path.dirname(zip_file), exist_ok=True)
+    if not os.path.isfile(zip_file):
+        print(f"> downloading cmake v{version}")
+        from urllib.request import urlretrieve
+        url = f"https://cmake.org/files/v{major_version}/cmake-{version}-win64-x64.zip"
+        print(url)
+        urlretrieve(url, zip_file)
+
+        print(f"> overwriting cmake with v{version}")
+        scripts_dir = os.path.join(sys.prefix, "Lib", "site-packages", "cmake", "data")
+        import zipfile
+        with zipfile.ZipFile(zip_file, 'r') as zh:
+            zh.extractall(scripts_dir)
+
+        print(f"> overwriting cmake succeeded")
+
+
 if __name__ == "__main__":
     if is_win:
         # windows requires the absolute latest of ninja and cmake to support VS2017 build tools
+        # until they are available on PyPi, we'll have to download and overwrite them in the virtualenv
         download_install_ninja_win()
         download_install_cmake_win()
 


### PR DESCRIPTION
Got rid of generating the empty libpython file with python and instead just run `subprocess.check_call(f"touch {work}/libpython.fake", shell=True)` where it is applicable. This avoided a bunch of lines of code.